### PR TITLE
fix(api): strip API keys from requests before agnost analytics capture

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -108,8 +108,26 @@ async function handleRequest(request: Request): Promise<Response> {
   const url = new URL(request.url);
   if (url.pathname === '/mcp' || url.pathname === '/') {
     url.pathname = '/api/mcp';
-    request = new Request(url.toString(), request);
   }
+
+  // Strip sensitive credentials from the request before passing to the MCP
+  // handler. Agnost analytics (trackMCP) wraps the transport and captures HTTP
+  // headers, query params, and the full URL from every request. Without
+  // sanitization, user API keys sent via ?exaApiKey= query param or
+  // Authorization header would be forwarded to the external analytics endpoint.
+  // The API key has already been extracted into `config` above, so tools still
+  // have access to it.
+  url.searchParams.delete('exaApiKey');
+  const sanitizedHeaders = new Headers(request.headers);
+  sanitizedHeaders.delete('authorization');
+  request = new Request(url.toString(), {
+    method: request.method,
+    headers: sanitizedHeaders,
+    body: request.body,
+    signal: request.signal,
+    // @ts-expect-error duplex is required for streaming request bodies in undici/Node
+    duplex: 'half',
+  });
 
   return handler(request);
 }


### PR DESCRIPTION
## Summary

Agnost analytics (`trackMCP`) wraps the MCP transport and captures HTTP headers, query params, and the full URL from every request. Without sanitization, user API keys sent via `?exaApiKey=` query param or `Authorization` header are forwarded to the external analytics endpoint at `api.agnost.ai`.

This is the same fix already applied to `exa-mcp-server` in [PR #292](https://github.com/exa-labs/exa-mcp-server/pull/292). The API key is extracted into `config` before sanitization, so tools still have full access to it — we just prevent it from leaking to the analytics layer.

**What changed:** In `api/mcp.ts`, before passing the request to the MCP handler:
- Delete `exaApiKey` from URL search params
- Delete `authorization` header
- Reconstruct the request with sanitized URL and headers

## Review & Testing Checklist for Human

- [ ] Verify that MCP tool calls still work with `Authorization: Bearer <key>` — the key should be extracted into config before the header is stripped
- [ ] Verify that MCP tool calls still work with `?exaApiKey=<key>` — same extraction-before-strip logic
- [ ] Confirm agnost event payloads at `api.agnost.ai` no longer contain API keys in the URL or headers metadata

### Notes

Ports the identical pattern from `exa-mcp-server/api/mcp.ts:493-510`.

Link to Devin session: https://app.devin.ai/sessions/06b7c6f02476460996d91ec514386ffa
Requested by: @10ishq
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/websets-mcp-server/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
