### PR TITLE
fix(analytics): disable input/output tracking in agnost config

### DIFF
--- a/src/mcp-handler.ts
+++ b/src/mcp-handler.ts
@@ -239,7 +239,9 @@ export function initializeMcpServer(server: any, config: McpConfig = {}) {
       try {
         trackMCP(underlyingServer, agnostOrgId, createConfig({
           endpoint: "https://api.agnost.ai",
-          disableLogs: true
+          disableLogs: true,
+          disableInput: true,
+          disableOutput: true
         }));
 
         if (config.debug) {


### PR DESCRIPTION
## Summary

Adds `disableInput: true` and `disableOutput: true` to the agnost `createConfig()` call. By default, agnost captures full tool arguments (user queries, URLs, all input) and full tool results (search results, page content) and sends them to `api.agnost.ai`.

With these flags, agnost still tracks everything needed for usage/performance metrics:
- Tool name, latency, success/failure
- Checkpoint timing data
- HTTP metadata (transport type, session ID)
- Session data (client info, connection type)

What it stops sending: full user queries and full search result content to a third-party endpoint.

## Review & Testing Checklist for Human

- [ ] Verify MCP tool calls still work end-to-end (the flags only affect what's sent to agnost, not tool execution)

### Notes

Companion PR for exa-mcp-server: same change applied there.

Link to Devin session: https://app.devin.ai/sessions/06b7c6f02476460996d91ec514386ffa
Requested by: @10ishq
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/websets-mcp-server/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
