### PR TITLE
Fix list_websets max limit back to 100

### DIFF
--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -18,6 +18,5 @@ export const API_CONFIG = {
     EVENTS: '/v0/events'
   },
   DEFAULT_LIMIT: 25,
-  MAX_LIMIT: 100,
-  MAX_LIMIT_WEBSETS: 200
+  MAX_LIMIT: 100
 } as const;

--- a/src/tools/listWebsets.ts
+++ b/src/tools/listWebsets.ts
@@ -11,7 +11,7 @@ export function registerListWebsetsTool(server: McpServer, config?: { exaApiKey?
     "list_websets",
     "List all websets in your account. Returns a paginated list of webset collections with their current status, searches, enrichments, imports, and metadata.",
     {
-      limit: z.number().optional().describe("Number of websets to return (default: 25, max: 200)"),
+      limit: z.number().optional().describe("Number of websets to return (default: 25, max: 100)"),
       cursor: z.string().optional().describe("Pagination cursor from previous response")
     },
     async ({ limit, cursor }) => {
@@ -24,7 +24,7 @@ export function registerListWebsetsTool(server: McpServer, config?: { exaApiKey?
         const client = new ExaApiClient(config?.exaApiKey || process.env.EXA_API_KEY || '');
 
         const params: Record<string, unknown> = {};
-        if (limit) params.limit = Math.min(limit, API_CONFIG.MAX_LIMIT_WEBSETS);
+        if (limit) params.limit = Math.min(limit, API_CONFIG.MAX_LIMIT);
         if (cursor) params.cursor = cursor;
         
         checkpoint('list_websets_request_prepared');


### PR DESCRIPTION
## Summary

The API reference docs stated `list_websets` supports `limit=200`, but live testing confirmed the API actually enforces a max of 100 (`limit=150` returns HTTP 400). This reverts the limit change from PR #22 back to 100.

## Review & Testing Checklist for Human

- [ ] `list_websets` with `limit=100` works
- [ ] `list_websets` without limit still defaults to 25

### Notes

Caught during E2E testing of all 23 tools against the live API. The API docs are out of date — the actual server enforces `limit <= 100` for list_websets.

Link to Devin session: https://app.devin.ai/sessions/ab0cd34fc15a4ab297378bad4664e10a
Requested by: @10ishq
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/websets-mcp-server/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
