### PR TITLE
[websets-mcp]: accept scope arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Align `create_search.scope` and `create_webset.searchScope` with the Websets
+  API by accepting arrays of scope sources instead of a single object.
+
 ### Documentation
 
 - Sync docs with the actual prod tool surface after the monitor removal
@@ -162,4 +167,3 @@ Or use multiple choice with options:
   ]
 }
 ```
-

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Creates a new webset collection with optional automatic population and enrichmen
 - `searchCriteria` (optional): Additional filtering criteria — `[{description: "..."}]` (max 5)
 - `searchBehavior` (optional): `"override"` (default) replaces existing items, `"append"` adds to them
 - `searchExclude` (optional): Imports/websets whose results to exclude — `[{source: "webset"|"import", id: "..."}]`
-- `searchScope` (optional): Scope the search to an existing import or webset — enables hop searches with a `relationship`
+- `searchScope` (optional): Scope the search to existing imports or websets — `[{source: "import"|"webset", id: "..."}]`; enables hop searches with a `relationship` object
 - `searchRecall` (optional): Whether to compute recall metrics for the search
 - `searchMaxPeoplePerCompany` (optional): Soft cap on people-per-employer for person searches
 - `searchMetadata` (optional): Key-value metadata to associate with the search

--- a/TOOL_SCHEMAS.md
+++ b/TOOL_SCHEMAS.md
@@ -49,6 +49,12 @@ Create a new Webset collection with optional search and enrichments.
   "externalId": "my-ai-startups-2024",
   "searchQuery": "AI startups in San Francisco",
   "searchCount": 20,
+  "searchScope": [
+    {
+      "source": "import",
+      "id": "import_abc123"
+    }
+  ],
   "searchCriteria": [
     {"description": "Founded after 2020"},
     {"description": "Has more than 10 employees"}
@@ -95,6 +101,12 @@ Create a new search to find and add items to an existing webset.
     {"description": "Operating in financial technology sector"},
     {"description": "Currently active"}
   ],
+  "scope": [
+    {
+      "source": "import",
+      "id": "import_abc123"
+    }
+  ],
   "behavior": "append",
   "recall": true,
   "metadata": {
@@ -114,6 +126,22 @@ Create a new search to find and add items to an existing webset.
 ### Valid Behaviors
 - `"override"` - Replaces existing items (default)
 - `"append"` - Adds to existing items
+
+### Scope Format
+`scope` and `searchScope` must be arrays, matching the Websets API:
+
+```json
+[
+  {
+    "source": "import",
+    "id": "import_abc123",
+    "relationship": {
+      "definition": "investors of these companies",
+      "limit": 5
+    }
+  }
+]
+```
 
 ---
 
@@ -439,4 +467,3 @@ All tools follow these consistent patterns:
 4. **Metadata**: Always `Record<string, string>` (object with string keys and values)
 
 This consistency ensures predictable usage across all Websets MCP tools.
-

--- a/src/tools/createSearch.ts
+++ b/src/tools/createSearch.ts
@@ -15,7 +15,7 @@ IMPORTANT PARAMETER FORMATS:
 - entity: MUST be an object like {type: "company"} (NOT a string). For "custom" type, include description: {type: "custom", description: "SaaS tools"}
 - criteria: MUST be array of objects like [{description: "..."}] (NOT array of strings)
 - exclude: Array of sources like [{source: "webset", id: "webset_123"}]
-- scope: Object for scoped/hop searches: {source: "import", id: "import_123", relationship: "investors of these companies"}
+- scope: Array of sources for scoped/hop searches: [{source: "import", id: "import_123", relationship: {definition: "investors of these companies", limit: 5}}]
 
 Example call:
 {
@@ -41,11 +41,14 @@ Example call:
         source: z.enum(['import', 'webset']),
         id: z.string()
       })).optional().describe("Exclude results found in these imports or websets. Example: [{source: 'webset', id: 'webset_123'}]"),
-      scope: z.object({
+      scope: z.array(z.object({
         source: z.enum(['import', 'webset']),
         id: z.string(),
-        relationship: z.string().optional().describe("For hop searches — describes the relationship to traverse (e.g., 'investors of these companies')")
-      }).optional().describe("Scope the search to items within an existing import or webset. Enables hop searches with relationship."),
+        relationship: z.object({
+          definition: z.string().describe("For hop searches — describes the relationship to traverse (e.g., 'investors of these companies')"),
+          limit: z.number().int().min(1).max(10)
+        }).optional()
+      })).optional().describe("Scope the search to items within existing imports or websets. Enables hop searches with relationship."),
       recall: z.boolean().optional().describe("Whether to compute recall metrics for the search"),
       maxPeoplePerCompany: z.number().int().min(1).optional().describe("Soft cap on how many people from the same employer to include in person searches"),
       metadata: z.record(z.coerce.string(), z.coerce.string()).optional().describe("Key-value pairs to associate with this search")

--- a/src/tools/createWebset.ts
+++ b/src/tools/createWebset.ts
@@ -46,11 +46,14 @@ AFTER CREATING: The response includes the webset ID. The webset will take time t
         source: z.enum(['import', 'webset']),
         id: z.string()
       })).optional().describe("Exclude results found in these imports or websets. Example: [{source: 'webset', id: 'webset_123'}]"),
-      searchScope: z.object({
+      searchScope: z.array(z.object({
         source: z.enum(['import', 'webset']),
         id: z.string(),
-        relationship: z.string().optional().describe("For hop searches — describes the relationship to traverse (e.g., 'investors of these companies')")
-      }).optional().describe("Scope the search to items within an existing import or webset. Enables hop searches with relationship."),
+        relationship: z.object({
+          definition: z.string().describe("For hop searches — describes the relationship to traverse (e.g., 'investors of these companies')"),
+          limit: z.number().int().min(1).max(10)
+        }).optional()
+      })).optional().describe("Scope the search to items within existing imports or websets. Enables hop searches with relationship."),
       searchRecall: z.boolean().optional().describe("Whether to compute recall metrics for the search"),
       searchMaxPeoplePerCompany: z.number().int().min(1).optional().describe("Soft cap on how many people from the same employer to include in person searches"),
       searchMetadata: z.record(z.coerce.string(), z.coerce.string()).optional().describe("Key-value pairs to associate with the search"),

--- a/src/tools/scopeSchema.test.ts
+++ b/src/tools/scopeSchema.test.ts
@@ -1,0 +1,151 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { initializeMcpServer } from "../mcp-handler.js";
+type JsonSchemaProperty = {
+  type?: string;
+  items?: JsonSchemaProperty;
+  properties?: Record<string, JsonSchemaProperty>;
+};
+
+const JsonSchemaPropertySchema: z.ZodType<JsonSchemaProperty> = z.lazy(() => z.object({
+  type: z.string().optional(),
+  items: JsonSchemaPropertySchema.optional(),
+  properties: z.record(JsonSchemaPropertySchema).optional()
+}).passthrough());
+
+const TextContentSchema = z.object({
+  type: z.literal("text"),
+  text: z.string()
+});
+
+async function createTestClient(enabledTools: string[]) {
+  const server = new McpServer({
+    name: "websets-server-test",
+    version: "1.0.1"
+  });
+  initializeMcpServer(server, { enabledTools });
+
+  const client = new Client({
+    name: "websets-test-client",
+    version: "1.0.0"
+  });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport)
+  ]);
+
+  return { client, close: () => client.close() };
+}
+
+describe("scope input schemas", () => {
+  it("exposes create_search.scope as an array schema", async () => {
+    const { client, close } = await createTestClient(["create_search"]);
+
+    try {
+      const { tools } = await client.listTools();
+      const createSearch = tools.find((tool) => tool.name === "create_search");
+      expect(createSearch).toBeDefined();
+
+      const scope = JsonSchemaPropertySchema.parse(createSearch?.inputSchema.properties?.scope);
+      expect(scope?.type).toBe("array");
+      expect(scope?.items?.properties?.source?.type).toBe("string");
+      expect(scope?.items?.properties?.id?.type).toBe("string");
+      expect(scope?.items?.properties?.relationship?.type).toBe("object");
+    } finally {
+      await close();
+    }
+  });
+
+  it("accepts array scope and rejects object scope for create_search", async () => {
+    const { client, close } = await createTestClient(["create_search"]);
+
+    try {
+      const accepted = await client.callTool({
+        name: "create_search",
+        arguments: {
+          websetId: "webset_123",
+          query: "AI startups",
+          scope: [{ source: "import", id: "import_123" }]
+        }
+      });
+      const acceptedContent = z.object({ content: z.array(TextContentSchema).min(1) }).parse(accepted);
+      const acceptedText = acceptedContent.content[0].text;
+      expect(acceptedText).toContain("Error creating search");
+      expect(acceptedText).not.toContain("Input validation error");
+
+      const rejected = await client.callTool({
+        name: "create_search",
+        arguments: {
+          websetId: "webset_123",
+          query: "AI startups",
+          scope: { source: "import", id: "import_123" }
+        }
+      });
+      expect(rejected.isError).toBe(true);
+      const rejectedContent = z.object({ content: z.array(TextContentSchema).min(1) }).parse(rejected);
+      const rejectedText = rejectedContent.content[0].text;
+      expect(rejectedText).toContain("Input validation error");
+      expect(rejectedText).toContain("Expected array");
+    } finally {
+      await close();
+    }
+  });
+
+  it("exposes create_webset.searchScope as an array schema", async () => {
+    const { client, close } = await createTestClient(["create_webset"]);
+
+    try {
+      const { tools } = await client.listTools();
+      const createWebset = tools.find((tool) => tool.name === "create_webset");
+      expect(createWebset).toBeDefined();
+
+      const searchScope = JsonSchemaPropertySchema.parse(
+        createWebset?.inputSchema.properties?.searchScope
+      );
+      expect(searchScope?.type).toBe("array");
+      expect(searchScope?.items?.properties?.source?.type).toBe("string");
+      expect(searchScope?.items?.properties?.id?.type).toBe("string");
+      expect(searchScope?.items?.properties?.relationship?.type).toBe("object");
+    } finally {
+      await close();
+    }
+  });
+
+  it("accepts array searchScope and rejects object searchScope for create_webset", async () => {
+    const { client, close } = await createTestClient(["create_webset"]);
+
+    try {
+      const accepted = await client.callTool({
+        name: "create_webset",
+        arguments: {
+          searchQuery: "AI startups",
+          searchScope: [{ source: "import", id: "import_123" }]
+        }
+      });
+      const acceptedContent = z.object({ content: z.array(TextContentSchema).min(1) }).parse(accepted);
+      const acceptedText = acceptedContent.content[0].text;
+      expect(acceptedText).toContain("Error creating webset");
+      expect(acceptedText).not.toContain("Input validation error");
+
+      const rejected = await client.callTool({
+        name: "create_webset",
+        arguments: {
+          searchQuery: "AI startups",
+          searchScope: { source: "import", id: "import_123" }
+        }
+      });
+      expect(rejected.isError).toBe(true);
+      const rejectedContent = z.object({ content: z.array(TextContentSchema).min(1) }).parse(rejected);
+      const rejectedText = rejectedContent.content[0].text;
+      expect(rejectedText).toContain("Input validation error");
+      expect(rejectedText).toContain("Expected array");
+    } finally {
+      await close();
+    }
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,15 @@ export interface ExcludeSource {
   id: string;
 }
 
+export interface SearchScopeSource {
+  source: 'import' | 'webset';
+  id: string;
+  relationship?: {
+    definition: string;
+    limit: number;
+  };
+}
+
 export interface Webset {
   id: string;
   object: 'webset';
@@ -63,11 +72,7 @@ export interface WebsetSearch {
   count: number;
   behavior: 'override' | 'append';
   exclude: ExcludeSource[];
-  scope?: {
-    source: 'import' | 'webset';
-    id: string;
-    relationship?: string;
-  };
+  scope?: SearchScopeSource[];
   progress?: {
     found: number;
     completion: number;
@@ -155,11 +160,7 @@ export interface CreateWebsetParams {
     criteria?: Array<{ description: string }>;
     behavior?: 'override' | 'append';
     exclude?: ExcludeSource[];
-    scope?: {
-      source: 'import' | 'webset';
-      id: string;
-      relationship?: string;
-    };
+    scope?: SearchScopeSource[];
     recall?: boolean;
     maxPeoplePerCompany?: number;
     metadata?: Record<string, string>;
@@ -185,11 +186,7 @@ export interface CreateSearchParams {
   criteria?: Array<{ description: string }>;
   behavior?: 'override' | 'append';
   exclude?: ExcludeSource[];
-  scope?: {
-    source: 'import' | 'webset';
-    id: string;
-    relationship?: string;
-  };
+  scope?: SearchScopeSource[];
   recall?: boolean;
   maxPeoplePerCompany?: number;
   metadata?: Record<string, string>;

--- a/src/utils/api.test.ts
+++ b/src/utils/api.test.ts
@@ -28,7 +28,8 @@ describe('ExaApiClient', () => {
       headers: {
         'accept': 'application/json',
         'content-type': 'application/json',
-        'x-api-key': apiKey
+        'x-api-key': apiKey,
+        'x-exa-integration': 'websets-mcp'
       },
       timeout: 30000
     });
@@ -108,4 +109,3 @@ describe('handleApiError', () => {
     expect(result.content[0].text).toContain('Helpful tip');
   });
 });
-


### PR DESCRIPTION
## Summary
- Change `create_search.scope` and `create_webset.searchScope` to accept arrays of scope sources, matching the Websets API.
- Update MCP types and docs/examples for scope arrays and relationship objects.
- Add MCP schema validation tests covering array acceptance and object rejection.

## Review & Testing Checklist for Human
- [x] Verify local patched MCP `create_webset` accepts `searchScope: [{ source: "import", id: "..." }]` against prod.
- [x] Verify local patched MCP `create_search` accepts `scope: [{ source: "import", id: "..." }]` against prod.
- [ ] Confirm any callers using the old single-object shape can switch to the API-compatible array shape.

### Notes
Local checks run:
- `npx tsc --noEmit`
- `npx vitest run`
- `npm --prefix /home/ubuntu/repos/websets-mcp-server run build`

Prod smoke test via local patched MCP:
- Import: `import_01kqsn1hv4hvk4c0bsc4bf42qs`
- Webset created with `searchScope` array: `webset_01kqsn1ma0w5mw0dkvezb8stg2`
- Search created with `scope` array: `wsearch_01kqsn2519jk0nzv5dq9738fg4`

Link to Devin session: https://app.devin.ai/sessions/44cca62fbe2a46c4aa834887a4fb5060
Requested by: @10ishq
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/websets-mcp-server/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
